### PR TITLE
Rename is_*? functions to *? and avoid name collisions with String module

### DIFF
--- a/lib/henchman.ex
+++ b/lib/henchman.ex
@@ -14,6 +14,5 @@ defmodule Henchman do
   defdelegate acronym(string), to: Henchman.String
   defdelegate word_limit(string, limit \\ 100, suffix \\ "..."), to: Henchman.String
   defdelegate randomize(length, type \\ :alphanumeric), to: Henchman.Randomizer, as: :generate
-  defdelegate randomize(length, type \\ :alphanumeric), to: Henchman.Randomizer, as: :generate
   defdelegate convert_length(value, from, to, show_unit \\ false, precision \\ 4), to: Henchman.Converter.Length, as: :convert
 end

--- a/lib/henchman.ex
+++ b/lib/henchman.ex
@@ -1,11 +1,19 @@
 defmodule Henchman do
-  @moduledoc false
-
-  defmacro __using__(_) do
-    quote do
-      alias Henchman.Randomizer
-      alias Henchman.String
-      alias Henchman.Converter.Length
-    end
-  end
+  defdelegate alpha?(string), to: Henchman.String
+  defdelegate alphanumeric?(string), to: Henchman.String
+  defdelegate blank?(string), to: Henchman.String
+  defdelegate lowercased?(string), to: Henchman.String
+  defdelegate uppercased?(string), to: Henchman.String
+  defdelegate numeric?(string), to: Henchman.String
+  defdelegate limit(string, length \\ 100, suffix \\ "..."), to: Henchman.String
+  defdelegate slug(string, delimeter \\ "-"), to: Henchman.String
+  defdelegate snake_case(string, delimeter \\ "_"), to: Henchman.String
+  defdelegate studly_case(string), to: Henchman.String
+  defdelegate title_case(string), to: Henchman.String
+  defdelegate camel_case(string), to: Henchman.String
+  defdelegate acronym(string), to: Henchman.String
+  defdelegate word_limit(string, limit \\ 100, suffix \\ "..."), to: Henchman.String
+  defdelegate randomize(length, type \\ :alphanumeric), to: Henchman.Randomizer, as: :generate
+  defdelegate randomize(length, type \\ :alphanumeric), to: Henchman.Randomizer, as: :generate
+  defdelegate convert_length(value, from, to, show_unit \\ false, precision \\ 4), to: Henchman.Converter.Length, as: :convert
 end

--- a/lib/string.ex
+++ b/lib/string.ex
@@ -32,55 +32,55 @@ defmodule Henchman.String do
   Determine if string contains alphabets only.
 
   ## Example
-      iex> Henchman.String.is_alpha?("ABCdef")#true
+      iex> Henchman.String.alpha?("ABCdef")#true
   """
-  @spec is_alpha?(String.t) :: String.t
-  def is_alpha?(value), do: String.match?(value, ~r/^[A-Za-z]*$/u)
+  @spec alpha?(String.t) :: String.t
+  def alpha?(value), do: String.match?(value, ~r/^[A-Za-z]*$/u)
 
   @doc """
   Determine if string contains alphabets and integers.
 
   ## Example
-      iex> Henchman.String.is_alphanumeric?("ABCdef123")#true
+      iex> Henchman.String.alphanumeric?("ABCdef123")#true
   """
-  @spec is_alphanumeric?(String.t) :: String.t
-  def is_alphanumeric?(value), do: String.match?(value, ~r/^[A-Za-z0-9]*$/u)
+  @spec alphanumeric?(String.t) :: String.t
+  def alphanumeric?(value), do: String.match?(value, ~r/^[A-Za-z0-9]*$/u)
 
   @doc """
   Determine if string is blank.
 
   ## Example
-      iex> Henchman.String.is_blank?("")#true
+      iex> Henchman.String.blank?("")#true
   """
-  @spec is_blank?(String.t) :: String.t
-  def is_blank?(value), do: String.match?(value, ~r/^[\s]*$/u)
+  @spec blank?(String.t) :: String.t
+  def blank?(value), do: String.match?(value, ~r/^[\s]*$/u)
 
   @doc """
   Determine if string contains lower case characters only.
 
   ## Example
-      iex> Henchman.String.is_lowercase?("def")#true
+      iex> Henchman.String.lowercased?("def")#true
   """
-  @spec is_lowercase?(String.t) :: String.t
-  def is_lowercase?(value), do: String.match?(value, ~r/^[a-z]*$/u)
+  @spec lowercased?(String.t) :: String.t
+  def lowercased?(value), do: String.match?(value, ~r/^[a-z]*$/u)
 
   @doc """
   Determine if string contains integers only.
 
   ## Example
-      iex> Henchman.String.is_numeric?("123")#true
+      iex> Henchman.String.numeric?("123")#true
   """
-  @spec is_numeric?(String.t) :: String.t
-  def is_numeric?(value), do: String.match?(value, ~r/^[0-9]*$/u)
+  @spec numeric?(String.t) :: String.t
+  def numeric?(value), do: String.match?(value, ~r/^[0-9]*$/u)
 
   @doc """
   Determine if string contains upper case characters only.
 
   ## Example
-      iex> Henchman.String.is_uppercase?("ABC")#true
+      iex> Henchman.String.uppercased?("ABC")#true
   """
-  @spec is_uppercase?(String.t) :: String.t
-  def is_uppercase?(value), do: String.match?(value, ~r/^[A-Z]*$/u)
+  @spec uppercased?(String.t) :: String.t
+  def uppercased?(value), do: String.match?(value, ~r/^[A-Z]*$/u)
 
   @doc """
   Limit characters within a string.

--- a/test/string_test.exs
+++ b/test/string_test.exs
@@ -1,69 +1,69 @@
 defmodule Henchman.StringTest do
   use ExUnit.Case
 
-  alias Henchman.String, as: Str
+  alias Henchman.String, as: String
 
   test "get acronym from string" do
-    assert "FB" = Str.acronym("fòô bàř")
+    assert "FB" = String.acronym("fòô bàř")
   end
 
   test "convert string to camel case" do
-    assert "fooBarBaz" = Str.camel_case("foo-bar_baz")
+    assert "fooBarBaz" = String.camel_case("foo-bar_baz")
   end
 
   test "check if string is alphabets only" do
-    assert Str.is_alpha?("ABCdef")
+    assert String.alpha?("ABCdef")
   end
 
   test "check if string is alphanumeric" do
-    assert Str.is_alphanumeric?("123ABCdef")
+    assert String.alphanumeric?("123ABCdef")
   end
 
   test "check if string is blank" do
-    assert Str.is_blank?(" ")
+    assert String.blank?(" ")
   end
 
   test "check if string is lower case" do
-    assert Str.is_lowercase?("foobar")
+    assert String.lowercased?("foobar")
   end
 
   test "check if string is numeric only" do
-    assert Str.is_numeric?("123")
+    assert String.numeric?("123")
   end
 
   test "check if string is upper case" do
-    assert Str.is_uppercase?("FOOBAR")
+    assert String.uppercased?("FOOBAR")
   end
 
   test "truncate characters in a string" do
-    assert "Foo bar ba..." = Str.limit("Foo bar baz baz", 10)
+    assert "Foo bar ba..." = String.limit("Foo bar baz baz", 10)
   end
 
   test "convert string to slug format" do
-    assert "foo-bar" = Str.slug("foo Bar")
+    assert "foo-bar" = String.slug("foo Bar")
   end
 
   test "convert string to snake case" do
-    assert "foo_bar_baz" = Str.snake_case("FooBarBaz")
+    assert "foo_bar_baz" = String.snake_case("FooBarBaz")
   end
 
   test "convert string to snake case with different delimiter" do
-    assert "foo-bar-baz" = Str.snake_case("fooBarBaz", "-")
+    assert "foo-bar-baz" = String.snake_case("fooBarBaz", "-")
   end
 
   test "convert string to studly case" do
-    assert "FooBarBaz" = Str.studly_case("foo-bar_baz")
+    assert "FooBarBaz" = String.studly_case("foo-bar_baz")
   end
 
   test "convert string to title case" do
-    assert "Foo Bar Baz" = Str.title_case("foo bar baz")
+    assert "Foo Bar Baz" = String.title_case("foo bar baz")
   end
 
   test "convert certain string to title case" do
-    assert "Foo Bar-baz" = Str.title_case("foo bar-baz")
+    assert "Foo Bar-baz" = String.title_case("foo bar-baz")
   end
 
   test "truncate word in a string" do
-    assert "Lorem ipsum dolor sit amet, consectetur adipiscing..." = Str.word_limit("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", 7)
+    assert "Lorem ipsum dolor sit amet, consectetur adipiscing..." = String.word_limit("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", 7)
   end
 end


### PR DESCRIPTION
This closes #6 and introduce delegated functions in the main module to avoid namespace collision with the String module

The naming convention is following the official docs http://elixir-lang.org/docs/stable/elixir/naming-conventions